### PR TITLE
Exclude field keep required value

### DIFF
--- a/packages/form/src/actions/change-value.js
+++ b/packages/form/src/actions/change-value.js
@@ -126,8 +126,10 @@ export const evaluateField = (formId, fieldId) => async (dispatch, getState) => 
 
   // if pass terms (exclude) - field is not part of the form - initiate its errors to empty array and disable to false
   if (exclude) {
-    // set field evaluation result - formId, fieldId, excluded, disabled, errors, dirty, required, empty, invalid
-    dispatch(setFieldEvaluation(formId, fieldId, exclude, false, false, false, false, false, []));
+    const field = form.model.fields[fieldId];
+
+    // set field evaluation result - formId, fieldId, excluded, disabled, dirty, required, empty, invalid, errors
+    dispatch(setFieldEvaluation(formId, fieldId, exclude, false, false, field.required, false, false, []));
     return;
   }
 
@@ -142,7 +144,7 @@ export const evaluateField = (formId, fieldId) => async (dispatch, getState) => 
     evaluateFieldComponentState(formId, fieldId)(dispatch, getState),
   ]);
 
-  // set field evaluation result - formId, fieldId, excluded, disabled, errors, dirty, required, empty, invalid
+  // set field evaluation result - formId, fieldId, excluded, disabled, dirty, required, empty, invalid, errors
   dispatch(setFieldEvaluation(formId, fieldId, exclude, results[0], results[1], results[2].required,
     results[2].empty, results[2].invalid, results[2].errors));
 };

--- a/packages/form/test/Form.spec.js
+++ b/packages/form/test/Form.spec.js
@@ -1020,6 +1020,37 @@ describe('Form', () => {
       });
       expect(form.invalid).toBeTruthy();
     });
+
+    it('field with exclude term and required=true, when its excluded - its should be keep required value', async () => {
+      const form = new Form();
+      simpleForm.model.data = { name: 'Custom' };
+      simpleForm.model.fields.lastName.required = true;
+      simpleForm.model.fields.lastName.dependencies = ['name'];
+      simpleForm.model.fields.lastName.excludeTerm = {
+        not: true,
+        name: 'equals',
+        args: { fieldId: 'name', value: 'Custom' }
+      },
+      await form.init(simpleForm.model, simpleForm.resources);
+      expect(form.fields.lastName.excluded).toBeFalsy();
+      expect(form.fields.lastName.required).toBeTruthy();
+      expect(form.fields.lastName.empty).toBeTruthy();
+      expect(form.fields.lastName.errors[0].name).toEqual('required');
+
+      // change value - to exclude the field
+      await form.changeValue('name', 'mock');
+      expect(form.fields.lastName.excluded).toBeTruthy();
+      expect(form.fields.lastName.required).toBeTruthy();
+      expect(form.fields.lastName.empty).toBeFalsy();
+      expect(form.fields.lastName.errors).toEqual([]);
+
+      // change value - to include the field
+      await form.changeValue('name', 'Custom');
+      expect(form.fields.lastName.excluded).toBeFalsy();
+      expect(form.fields.lastName.required).toBeTruthy();
+      expect(form.fields.lastName.empty).toBeTruthy();
+      expect(form.fields.lastName.errors[0].name).toEqual('required');
+    });    
   });
 
   describe('dirty', () => {


### PR DESCRIPTION
Field that is both "required=true" and has exclude term, when field is excluded - original "required" value turn to false.

Expected:
Field that is both "required=true" and has exclude term should keep original required value when changing to excluded and back to included.