### PR TITLE
fix-demos-scrollto-selected-menu-item

### DIFF
--- a/packages/react-form/src/website/Root.e2e.js
+++ b/packages/react-form/src/website/Root.e2e.js
@@ -132,7 +132,7 @@ async function testReactDemos(page) {
   // run demos e2e
   await asyncForEach(menu.slice(1), async (parentItem) => {
     // open parent
-    const parentItemSelector = `#\\${parentItem.id}`;
+    const parentItemSelector = `[item-id="${parentItem.id}"]`;
     await page.click(parentItemSelector);
     await page.waitFor(ANIMATION_DURATION);
 

--- a/packages/react-form/src/website/Root.e2e.js
+++ b/packages/react-form/src/website/Root.e2e.js
@@ -76,15 +76,15 @@ async function testHomepageNavigation(page) {
   expect(itemsBeforeOpen).toHaveLength(10);
 
   // verify child items not appear yet
-  let firstDemo = await page.$('[id="/basics/basic"][role="button"]');
+  let firstDemo = await page.$('[item-id="/basics/basic"][role="button"]');
   expect(firstDemo).toBeFalsy();
 
   // open parent item of "basics"
-  await page.click('[id="/basics"][role="button"]');
+  await page.click('[item-id="/basics"][role="button"]');
   await page.waitFor(ANIMATION_DURATION);
 
   // verify its sub items appear on the screen
-  firstDemo = await page.$('[id="/basics/basic"][role="button"]');
+  firstDemo = await page.$('[item-id="/basics/basic"][role="button"]');
   expect(firstDemo).toBeTruthy();
 
   // verify that home is presented and not any example
@@ -94,7 +94,7 @@ async function testHomepageNavigation(page) {
   expect(home).toBeTruthy();
 
   // click first example item
-  await page.click('[id="/basics/basic"][role="button"]');
+  await page.click('[item-id="/basics/basic"][role="button"]');
 
   // verify that home is not presented and first example is presented
   demoContainer = await page.$('#example-container');
@@ -165,7 +165,7 @@ async function testDemos(page, demos) {
 
 async function testDemo(page, demoId, demoWait) {
   // click on the demo item om the left sidebar
-  const itemSelector = `#${demoId.replace(/\//g, '\\/')}`;
+  const itemSelector = `[item-id="${demoId.replace(/\//g, '\\/')}"]`;
   await page.click(itemSelector);
   
   // verify html tab

--- a/packages/react-form/src/website/components/NestedList/NestedList.jsx
+++ b/packages/react-form/src/website/components/NestedList/NestedList.jsx
@@ -46,7 +46,7 @@ export default class NestedList extends React.Component {
 
     return (!item.hide && <React.Fragment key={item.id}>
       <Styled.ListItem
-        id={item.id}
+        item-id={item.id}
         level={nestedLevel}
         button={true}
         component={!item.items || item.hideChildren ? Link : undefined}

--- a/packages/react-layout/src/website/Root.e2e.js
+++ b/packages/react-layout/src/website/Root.e2e.js
@@ -76,15 +76,15 @@ async function testHomepageNavigation(page) {
   expect(itemsBeforeOpen).toHaveLength(2);
 
   // verify child items not appear yet
-  let firstDemo = await page.$('[id="/item/layouts"][role="button"]');
+  let firstDemo = await page.$('[item-id="/item/layouts"][role="button"]');
   expect(firstDemo).toBeFalsy();
 
   // open parent item of "item"
-  await page.click('[id="/item"][role="button"]');
+  await page.click('[item-id="/item"][role="button"]');
   await page.waitFor(ANIMATION_DURATION);
 
   // verify its sub items appear on the screen
-  firstDemo = await page.$('[id="/item/layouts"][role="button"]');
+  firstDemo = await page.$('[item-id="/item/layouts"][role="button"]');
   expect(firstDemo).toBeTruthy();
 
   // verify that home is presented and not any example
@@ -94,7 +94,7 @@ async function testHomepageNavigation(page) {
   expect(home).toBeTruthy();
 
   // click first example item
-  await page.click('[id="/item/layouts"][role="button"]');
+  await page.click('[item-id="/item/layouts"][role="button"]');
 
   // verify that home is not presented and first example is presented
   demoContainer = await page.$('#example-container');
@@ -136,7 +136,7 @@ async function testReactDemos(page) {
 
 async function testParentDemos(page, parentItem) {
   // click on parent item - on left sidebar
-  const parentItemSelector = `#\\${parentItem.id}`;
+  const parentItemSelector = `[item-id="${parentItem.id}"]`;
   await page.click(parentItemSelector);
   await page.waitFor(ANIMATION_DURATION);
 
@@ -164,7 +164,7 @@ async function testDemos(page, demos) {
 
 async function testDemo(page, demoId, demoWait) {
   // click on the demo item om the left sidebar
-  const itemSelector = `#${demoId.replace(/\//g, '\\/')}`;
+  const itemSelector = `[item-id="${demoId.replace(/\//g, '\\/')}"]`;
   await page.click(itemSelector);
   // verify html tab
   let htmlTabContainer = await page.$('#example-html');

--- a/packages/react-layout/src/website/components/NestedList/NestedList.jsx
+++ b/packages/react-layout/src/website/components/NestedList/NestedList.jsx
@@ -54,7 +54,7 @@ export default class NestedList extends React.Component {
 
     return (!item.hide && <React.Fragment key={item.id}>
       <Styled.ListItem
-        id={item.id}
+        item-id={item.id}
         level={nestedLevel}
         button={true}
         component={!item.items || item.hideChildren ? Link : undefined}


### PR DESCRIPTION
Fix in react-form and react-layout demos - each time click on a left menu - the page scrolls to the selected left menu item that is not needed.